### PR TITLE
Fixes/Issue with JSON.parse unable to parse stored items

### DIFF
--- a/src/components/ItemList.jsx
+++ b/src/components/ItemList.jsx
@@ -42,14 +42,6 @@ const ItemList = () => {
 
   const { items, handleDeleteItem, handleToggleItem } = useItemsContext();
 
-  if (items.length === 0) {
-    return (
-      <p className="empty-list">
-        Your list is currently empty. Add your first item to get started!
-      </p>
-    );
-  }
-
   const sortedItems = useMemo(
     () =>
       [...items].sort((a, b) => {
@@ -69,6 +61,14 @@ const ItemList = () => {
       }),
     [items, sortBy],
   );
+
+  if (items.length === 0) {
+    return (
+      <p className="empty-list">
+        Your list is currently empty. Add your first item to get started!
+      </p>
+    );
+  }
 
   return (
     <ul className="item-list">

--- a/src/contexts/ItemsContextProvider.jsx
+++ b/src/contexts/ItemsContextProvider.jsx
@@ -6,7 +6,7 @@ export const ItemsContext = createContext();
 
 const ItemsContextProvider = ({ children }) => {
   const [items, setItems] = useState(() => {
-    return JSON.parse(localStorage.getItem('trekbag-items') || INITIAL_ITEMS);
+    return JSON.parse(localStorage.getItem('trekbag-items')) || INITIAL_ITEMS;
   });
 
   const numberOfItemsPacked = items.filter((item) => item.packed).length;


### PR DESCRIPTION
## Tasks Done
- Fix the error of `JSON.parse` method wrapping the `INITIAL_ITEMS` array instead of just `localStorage's` stringified items
- Fix the issue of the app crashing while removing all items from the list because of the conditional hook call i.e., the hook `useMemo` which is being used to optimize the sorting of the items (based on `default`, `name`, `packed`, and `unpacked` statuses) was being called after an early return `if-statement`